### PR TITLE
add requests as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ setup(
     name='googledrivedownloader',
     version='0.4',
     packages=['google_drive_downloader'],
+    install_requires=['requests'],
     url='https://github.com/ndrplz/google-drive-downloader',
     download_url='https://github.com/ndrplz/google-drive-downloader/archive/0.2.tar.gz',
     license='MIT',


### PR DESCRIPTION
Dependencies should be declared by an `install_requires` directive in `setup.py` so that `pip install googledrivedownloader` installs them automatically. At least `requests` is a dependency that should be listed there.