### PR TITLE
Console utility function

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,16 @@ This will download a `mnist.zip` file into a `data` folder and unzip it.
 ### Tips
 * Set `showsize=True` to see the download progress
 * Set `overwrite=True` you really want to overwrite an already existent file.
+
+### Use from console
+
+Once installed, the library can also be used to download directly from your console.
+
+```bash
+# show help for the parameters
+googledrivedownloader -h
+
+# download the file of the previous example
+# parameters are in the order: file_id dest_path [overwrite] [unzip] [showsize]
+googledrivedownloader "1iytA1n2z4go3uVCwE__vIKouTKyIDjEq" "./data/mnist.zip" False True
+```

--- a/google_drive_downloader/cli.py
+++ b/google_drive_downloader/cli.py
@@ -1,0 +1,5 @@
+import plac
+from .google_drive_downloader import GoogleDriveDownloader
+
+def entry_point():
+    plac.call(GoogleDriveDownloader.download_file_from_google_drive)

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,14 @@ setup(
     name='googledrivedownloader',
     version='0.4',
     packages=['google_drive_downloader'],
+    install_requires=['plac'],
     url='https://github.com/ndrplz/google-drive-downloader',
     download_url='https://github.com/ndrplz/google-drive-downloader/archive/0.2.tar.gz',
     license='MIT',
     author='Davide Abati and Andrea Palazzi',
     author_email='ndrplz@gmail.com',
-    description='Minimal class to download shared files from Google Drive.'
+    description='Minimal class to download shared files from Google Drive.',
+    entry_points={
+        "console_scripts": ["googledrivedownloader=google_drive_downloader.cli:entry_point"]
+    }
 )


### PR DESCRIPTION
With this little edit, the library can be called directly from the console as a command.
The parameters are the same as the ones used to call the function from python.
The parsing, management and documentation of the arguments is performed using [plac](http://micheles.github.io/plac/)