### PR TITLE
Bypass virus scan by using new Google Drive API endpoint

### DIFF
--- a/google_drive_downloader/google_drive_downloader.py
+++ b/google_drive_downloader/google_drive_downloader.py
@@ -15,6 +15,7 @@ class GoogleDriveDownloader:
 
     CHUNK_SIZE = 32768
     DOWNLOAD_URL = 'https://docs.google.com/uc?export=download'
+    GG_DRIVE_URL = 'https://drive.google.com/u/2/uc?export=download'
 
     @staticmethod
     def download_file_from_google_drive(file_id, dest_path, overwrite=False, unzip=False, showsize=False):
@@ -53,12 +54,14 @@ class GoogleDriveDownloader:
             print('Downloading {} into {}... '.format(file_id, dest_path), end='')
             stdout.flush()
 
-            response = session.get(GoogleDriveDownloader.DOWNLOAD_URL, params={'id': file_id}, stream=True)
+            # response = session.get(GoogleDriveDownloader.DOWNLOAD_URL, params={'id': file_id}, stream=True)
 
-            token = GoogleDriveDownloader._get_confirm_token(response)
-            if token:
-                params = {'id': file_id, 'confirm': token}
-                response = session.get(GoogleDriveDownloader.DOWNLOAD_URL, params=params, stream=True)
+            # token = GoogleDriveDownloader._get_confirm_token(response)
+            # if token:
+            #     params = {'id': file_id, 'confirm': token}
+            #     response = session.get(GoogleDriveDownloader.DOWNLOAD_URL, params=params, stream=True)
+
+            response = session.post(GoogleDriveDownloader.GG_DRIVE_URL, params={'id': file_id, 'confirm': 't'}, stream=True)
 
             if showsize:
                 print()  # Skip to the next line

--- a/google_drive_downloader/google_drive_downloader.py
+++ b/google_drive_downloader/google_drive_downloader.py
@@ -15,7 +15,6 @@ class GoogleDriveDownloader:
 
     CHUNK_SIZE = 32768
     DOWNLOAD_URL = 'https://docs.google.com/uc?export=download'
-    GG_DRIVE_URL = 'https://drive.google.com/u/2/uc?export=download'
 
     @staticmethod
     def download_file_from_google_drive(file_id, dest_path, overwrite=False, unzip=False, showsize=False):
@@ -54,14 +53,7 @@ class GoogleDriveDownloader:
             print('Downloading {} into {}... '.format(file_id, dest_path), end='')
             stdout.flush()
 
-            # response = session.get(GoogleDriveDownloader.DOWNLOAD_URL, params={'id': file_id}, stream=True)
-
-            # token = GoogleDriveDownloader._get_confirm_token(response)
-            # if token:
-            #     params = {'id': file_id, 'confirm': token}
-            #     response = session.get(GoogleDriveDownloader.DOWNLOAD_URL, params=params, stream=True)
-
-            response = session.post(GoogleDriveDownloader.GG_DRIVE_URL, params={'id': file_id, 'confirm': 't'}, stream=True)
+            response = session.post(GoogleDriveDownloader.DOWNLOAD_URL, params={'id': file_id, 'confirm': 't'}, stream=True)
 
             if showsize:
                 print()  # Skip to the next line
@@ -79,13 +71,6 @@ class GoogleDriveDownloader:
                     print('Done.')
                 except zipfile.BadZipfile:
                     warnings.warn('Ignoring `unzip` since "{}" does not look like a valid zip file'.format(file_id))
-
-    @staticmethod
-    def _get_confirm_token(response):
-        for key, value in response.cookies.items():
-            if key.startswith('download_warning'):
-                return value
-        return None
 
     @staticmethod
     def _save_response_content(response, destination, showsize, current_size):


### PR DESCRIPTION
This PR aims at fixing the Virus scan error and request for confirmation.

I have discovered that Google Drive changed the method of downloading endpoint from GET to POST, so I updated the code to fix that issue. Also, to pass the virus scan we just need to add a **confirm="t"** field to the URL, so I removed the code to read the token from the previous version.