### PR TITLE
minor: Add support for files requiring virus scan confirmation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+__pycache__
+
 .idea/
 data/
 dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "googledrivedownloader"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
   "requests",
 ]

--- a/src/googledrivedownloader/download.py
+++ b/src/googledrivedownloader/download.py
@@ -20,13 +20,6 @@ def _sizeof_fmt(num, suffix='B'):
     return '{:.1f} {}{}'.format(num, 'Yi', suffix)
 
 
-def _get_confirm_token(response):
-    for key, value in response.cookies.items():
-        if key.startswith('download_warning'):
-            return value
-    return None
-
-
 def _save_response_content(response, destination, showsize, current_size):
     with open(destination, 'wb') as f:
         for chunk in response.iter_content(CHUNK_SIZE):
@@ -74,12 +67,8 @@ def download_file_from_google_drive(file_id, dest_path, overwrite=False, unzip=F
         print('Downloading {} into {}... '.format(file_id, dest_path), end='')
         stdout.flush()
 
-        response = session.get(DOWNLOAD_URL, params={'id': file_id}, stream=True)
-
-        token = _get_confirm_token(response)
-        if token:
-            params = {'id': file_id, 'confirm': token}
-            response = session.get(DOWNLOAD_URL, params=params, stream=True)
+        params = {'id': file_id, 'confirm': True}
+        response = session.post(DOWNLOAD_URL, params=params, stream=True)
 
         if showsize:
             print()  # Skip to the next line


### PR DESCRIPTION
The download was not working for large files (or particular file structures like zip of zips) where Google Drive was unable to scan the file for viruses.

Multiple MRs addressed the same issue parsing the first response content: https://github.com/ndrplz/google-drive-downloader/pull/28 https://github.com/ndrplz/google-drive-downloader/pull/32/

However, it seems that simply replacing the GET with a POST already cuts it.

Possible explanations from ChatGPT:
- Google Drive treats POST as an intentional download request
- Google might have a different backend handling for POST downloads
- The confirm=True parameter might act as a global override

In any case, it seems to work in both cases now.